### PR TITLE
set witdh to 100% in select2 so it stays inside parent div when respo…

### DIFF
--- a/app/assets/stylesheets/decidim/notify/notify.scss
+++ b/app/assets/stylesheets/decidim/notify/notify.scss
@@ -9,6 +9,7 @@
   display: none;
 }
 .select2-container--foundation {
+  width: 100% !important;
   .select2-dropdown {
     border-radius: 4px;
   }
@@ -68,6 +69,7 @@
     textarea {
       border: 1px solid #cacaca;
       border-radius: 4px;
+      resize: vertical;
     }
   }
   input, textarea {


### PR DESCRIPTION
This PR closes #9.

As shown in #9 the selects in notify may overflow their parent div when resizing the window. This PR will set a width of 100% to them so they don't do it.

It will also change the behaviour of the text area to only let it resize vertically.

![image](https://user-images.githubusercontent.com/41389482/107669050-a3da9100-6c91-11eb-9e7a-7002d10c3907.png)
