### PR TITLE
fix(sass): division deprecation warning

### DIFF
--- a/app/packs/stylesheets/decidim/notify/hexagon.scss
+++ b/app/packs/stylesheets/decidim/notify/hexagon.scss
@@ -16,12 +16,12 @@
   $root2: 1.41421356237;
   $root3: 1.73205080757;
   $scaleFactor: 0.57735026919; // = tan(30deg) *this smushes a square into a 60deg/120deg rhombus:
-  $scaleFactor1: 1/$scaleFactor;
+  $scaleFactor1: math.div(1, $scaleFactor);
 
-  $height: $width/$root3;
-  $capWidth: $width/$root2; // caps = the top and bottom triangles
+  $height: math.div($width, $root3);
+  $capWidth: math.div($width, $root2); // caps = the top and bottom triangles
   $capBorderWidth: $borderWidth*$root2;
-  $capBorderHeight: $borderWidth*2/$root3; //needed to offset bg pos
+  $capBorderHeight: math.div($borderWidth*2, $root3); //needed to offset bg pos
   $border: solid $borderWidth $borderColor;
   $capBorder: solid $capBorderWidth $borderColor;
   $coverWidth: $width - $borderWidth*2; //the cover up rectangle
@@ -29,14 +29,14 @@
   $capHeight: $height - $capBorderHeight;
   $bgHeight: $capHeight*2;
   $bgHeight: $height*2 - ($capBorderHeight*2);
-  $bgHeight: $height*2 - ($borderWidth*2/$root3)*2;
-  $bgHeight: $height*2 - ($borderWidth/$root3)*4;
-  $translateBG: -$height/2 + $capBorderHeight/2;
+  $bgHeight: $height*2 - math.div($borderWidth*2, $root3)*2;
+  $bgHeight: $height*2 - math.div($borderWidth, $root3)*4;
+  $translateBG: -$height*0.5 + $capBorderHeight*0.5;
 
   position: relative;
   width: $width;
   height: $height;
-  margin: $height/2 auto;
+  margin: $height*0.5 auto;
   background-color: $color;
   background-size: auto $bgHeight; //fit to total height, minus borders
   background-position: center;
@@ -55,7 +55,7 @@
     overflow: hidden;
     transform: scaleY($scaleFactor) rotate(-45deg);
     background: inherit;
-    left: ($width - $capWidth)/2 - $borderWidth; //offset by half the difference in
+    left: ($width - $capWidth)*0.5 - $borderWidth; //offset by half the difference in
   }
 
   //counter transform the bg image on the caps
@@ -74,7 +74,7 @@
 
   //send top to top and bottom to bottom
   .hex1 {
-    top: -$width/$root2/2;  //half the rhombus height
+    top: math.div(-$width, $root2)*0.5;  //half the rhombus height
     border-top: $capBorder;
     border-right: $capBorder;
 
@@ -84,7 +84,7 @@
   }
 
   .hex2 {
-    bottom: -$width/$root2/2; //half the rhombus height
+    bottom: math.div(-$width, $root2)*0.5; //half the rhombus height
     border-bottom: $capBorder;
     border-left: $capBorder;
 
@@ -108,12 +108,12 @@
   // Role
   .code {
     z-index: 10;
-    bottom:-$width/4;
-    right:-$width/6;
+    bottom:-$width*0.25;
+    right:math.div(-$width, 6);
     position: absolute;
-    width: $width/2;
-    height: $width/2;
-    border-radius:$width/2;
+    width: $width*0.5;
+    height: $width*0.5;
+    border-radius:$width*0.5;
     background-color: rgba(200,200,200,0.9);
     color:#000;
     font-size: 1.2em;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@rails/actioncable": "6.0.4",
         "select2": "^4.1.0-rc.0"
       },
       "devDependencies": {
@@ -513,6 +514,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rails/actioncable": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.0.4.tgz",
+      "integrity": "sha512-dTirb2EMt/YPVkEZp3GSXwjR+dYjbK0b0NtupEiuwj5dsffFfRnvtPK/aqLibZH6J3G8EAHnuoAaTF0neq2ggw=="
     },
     "node_modules/@stylelint/postcss-css-in-js": {
       "version": "0.37.2",
@@ -4846,6 +4852,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@rails/actioncable": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.0.4.tgz",
+      "integrity": "sha512-dTirb2EMt/YPVkEZp3GSXwjR+dYjbK0b0NtupEiuwj5dsffFfRnvtPK/aqLibZH6J3G8EAHnuoAaTF0neq2ggw=="
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",


### PR DESCRIPTION
## Description

Some deprecation warnings appear when compiling with `webpacker` , this PR tries to fix this warnings, used the [automated migrator](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration) suggested in the warning.

more info https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($borderWidth * 2, $root3) or calc($borderWidth * 2 / $root3)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
24 │   $capBorderHeight: $borderWidth*2/$root3; 
   │                     ^^^^^^^^^^^^^^^^^^^^^
   ╵
    ../../../.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/decidim-notify-0.5/app/packs/stylesheets/decidim/notify/hexagon.scss 24:21  hexagon()
```