### PR TITLE
Fixed submit button on notify form

### DIFF
--- a/app/packs/stylesheets/decidim/notify/notify.scss
+++ b/app/packs/stylesheets/decidim/notify/notify.scss
@@ -10,6 +10,11 @@
 .select2-hidden-accessible {
   display: none;
 }
+
+.button--double{
+  width: fit-content;
+}
+
 .select2-container--foundation {
   width: 100% !important;
   .select2-dropdown {


### PR DESCRIPTION
Fixed submit button overlapping content on small screens.
Before:
![image](https://github.com/Platoniq/decidim-module-notify/assets/72018461/c1133522-86de-4d8b-b6be-9aab2995e533)
After:
![image](https://github.com/Platoniq/decidim-module-notify/assets/72018461/52783044-0811-44f4-87fd-1c24705b7644)
